### PR TITLE
Making gradle happier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,9 @@ dependencies {
 // in order to make them all available at runtime. Also adding the manifest so WPILib
 // knows where to look for our Robot Class.
 jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
-    DuplicatesStrategy.INCLUDE
 }
 
 // Custom rules


### PR DESCRIPTION
explicitly set duplicates strategy for zip files for jar task in gradle
https://docs.gradle.org/current/userguide/upgrading_version_5.html#implicit_duplicate_strategy_for_copy_or_archive_tasks_has_been_deprecated
Before:
```
$ ./gradlew build --warning-mode all
> Task :jar
Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0. Duplicate path: "META-INF/LICENSE". Explicitly set the duplicates strategy to 'DuplicatesStrategy.INCLUDE' if you want to allow duplicate paths.
Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0. Duplicate path: "module-info.class". Explicitly set the duplicates strategy to 'DuplicatesStrategy.INCLUDE' if you want to allow duplicate paths.
Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0. Duplicate path: "META-INF/NOTICE". Explicitly set the duplicates strategy to 'DuplicatesStrategy.INCLUDE' if you want to allow duplicate paths.

BUILD SUCCESSFUL in 1s
5 actionable tasks: 5 executed
```
After:
```
$ ./gradlew build --warning-mode all

BUILD SUCCESSFUL in 1s
5 actionable tasks: 5 executed
```